### PR TITLE
Additional parameter for chrome/chromium binary location

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ parser.add_argument(
 )
 parser.add_argument("--exalias", type=str, default="PANCAKESWAP")
 parser.add_argument("--reverse", type=bool, default=False)
-
+parser.add_argument("--path", type=str, default="C:\Program Files\Google\Chrome\Application\chrome.exe")
 
 args = parser.parse_args()
 
@@ -22,6 +22,7 @@ currency2 = args.c2
 target_exchange = args.ex
 exchange_alias = args.exalias
 reverse = args.reverse
+bin_path = args.path
 
 db = sqliteDB()
 
@@ -30,9 +31,9 @@ db._table_exists()
 
 # url defaults to pancakeswap.finance if not provided
 if target_exchange == "":
-    scraper = Scraper(url="https://exchange.pancakeswap.finance/#/swap")
+    scraper = Scraper(url="https://exchange.pancakeswap.finance/#/swap", bin_path=bin_path)
 else:
-    scraper = Scraper(url=target_exchange)
+    scraper = Scraper(url=target_exchange, bin_path=bin_path)
 
 scraper.select_pair(currency1=currency1, currency2=currency2, reverse=reverse)
 

--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.keys import Keys
 
 
 class Scraper:
-    def __init__(self, url=""):
+    def __init__(self, url="", bin_path=""):
         # placeholders
         self.pair = ""
         self.currency1_amount = -1
@@ -13,9 +13,10 @@ class Scraper:
 
         # LOAD Site
         option = webdriver.ChromeOptions()
+        option.binary_location = bin_path
 
         self.browser = webdriver.Chrome(
-            executable_path="./drivers/chromedriver", chrome_options=option
+            executable_path="./drivers/chromedriver", options=option
         )
         self.browser.get(url)
         self.browser.implicitly_wait(5)


### PR DESCRIPTION
Used options instead of chrome_options (deprecated).
Added path argument to parser to specify binary location when chrome/chromium isn't installed in default location.